### PR TITLE
Docker Inter-service communication fix.

### DIFF
--- a/compose-wrapper-mockgateway.yaml
+++ b/compose-wrapper-mockgateway.yaml
@@ -10,6 +10,12 @@ services:
     - '8090:8090'
     networks:
     - docker_network
+    healthcheck:
+      test: java --version || exit 1
+      interval: 10s
+      retries: 10
+      start_period: 5s
+      timeout: 60s
 
   mongodb:
     image: mongodb/mongodb-community-server:latest
@@ -26,10 +32,14 @@ services:
     ports:
     - '8082:8082'
     depends_on:
-    - gateway
-    - mongodb
+      gateway:
+        condition: service_healthy
+      mongodb:
+        condition: service_started
     networks:
     - docker_network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   mongodb_vol:

--- a/mock-gateway/src/main/resources/wrapper.yaml
+++ b/mock-gateway/src/main/resources/wrapper.yaml
@@ -5,7 +5,7 @@ info:
   title: Wrapper
   description: Wrapper
 servers:
-- url: http://localhost:8082
+- url: http://abdm-wrapper:8082
   description: Wrapper
 paths:
   /v0.5/care-contexts/discover:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,7 +43,7 @@ clientId=
 clientSecret=
 
 #HIP
-hipBaseUrl=http://localhost:8081
+hipBaseUrl=http://host.docker.internal:8081
 getPatientPath=/v1/patients
 getHealthInformationPath=/v1/health-information
 


### PR DESCRIPTION
- Made changes in compose-wrapper-mockgateway.yaml to make inter-service communication work.
- Also, wrapper shall be able to communicate to any service hosted by HMIS e.g. patient or health information on their local machine.