### PR TITLE
Modified code to avoid request not found exception.

### DIFF
--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/services/RequestLogService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/services/RequestLogService.java
@@ -328,9 +328,6 @@ public class RequestLogService<T> {
 
   public void updateStatus(String requestId, RequestStatus requestStatus) {
     log.info("GatewayRequestId: " + requestId + "requestStatus: " + requestStatus);
-    Query query1 = new Query(Criteria.where("gatewayRequestId").is(requestId));
-    RequestLog existingRecord = mongoTemplate.findOne(query1, RequestLog.class);
-    log.info(existingRecord.toString());
     Query query = new Query(Criteria.where(FieldIdentifiers.GATEWAY_REQUEST_ID).is(requestId));
     Update update = new Update();
     update.set(FieldIdentifiers.STATUS, requestStatus);

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/tables/helpers/RequestStatus.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/tables/helpers/RequestStatus.java
@@ -2,6 +2,7 @@
 package com.nha.abdm.wrapper.hip.hrp.database.mongo.tables.helpers;
 
 public enum RequestStatus {
+  INITIATING("Request is being initiated"),
   AUTH_INIT_ACCEPTED("HIP Initiated link auth init request accepted by gateway"),
   AUTH_INIT_ERROR("Error thrown by Gateway for HIP Initiated link auth init"),
   AUTH_ON_INIT_ERROR("Error thrown by Gateway for HIP Initiated link auth on init"),

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/link/hipInitiated/HipLinkService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/link/hipInitiated/HipLinkService.java
@@ -100,18 +100,20 @@ public class HipLinkService implements HipLinkInterface {
             .build();
 
     log.debug("LinkAuthInit : " + linkAuthInit.toString());
-
+    requestLogService.persistHipLinkRequest(linkRecordsRequest, RequestStatus.INITIATING, null);
     try {
       ResponseEntity<GenericResponse> response =
           requestManager.fetchResponseFromGateway(linkAuthInitPath, linkAuthInit);
       log.debug(linkAuthInitPath + " : linkAuthInit: " + response.getStatusCode());
       if (response.getStatusCode() == HttpStatus.ACCEPTED) {
-        requestLogService.persistHipLinkRequest(
-            linkRecordsRequest, RequestStatus.AUTH_INIT_ACCEPTED, null);
+        requestLogService.updateStatus(
+            linkAuthInit.getRequestId(), RequestStatus.AUTH_INIT_ACCEPTED);
       } else if (Objects.nonNull(response.getBody())
           && Objects.nonNull(response.getBody().getErrorResponse())) {
-        requestLogService.persistHipLinkRequest(
-            linkRecordsRequest, RequestStatus.AUTH_INIT_ERROR, null);
+        requestLogService.updateError(
+            linkAuthInit.getRequestId(),
+            response.getBody().getErrorResponse().getMessage(),
+            RequestStatus.AUTH_CONFIRM_ERROR);
         return FacadeResponse.builder()
             .error(response.getBody().getErrorResponse())
             .clientRequestId(linkRecordsRequest.getRequestId())
@@ -200,7 +202,7 @@ public class HipLinkService implements HipLinkInterface {
             linkConfirmRequest.getRequestId(), RequestStatus.AUTH_CONFIRM_ACCEPTED);
       } else if (Objects.nonNull(response.getBody())) {
         requestLogService.updateError(
-            requestLog.getGatewayRequestId(),
+            linkConfirmRequest.getRequestId(),
             response.getBody().getErrorResponse().getMessage(),
             RequestStatus.AUTH_CONFIRM_ERROR);
       }
@@ -381,7 +383,7 @@ public class HipLinkService implements HipLinkInterface {
       } else if (Objects.nonNull(response.getBody())
           && Objects.nonNull(response.getBody().getErrorResponse())) {
         requestLogService.updateError(
-            requestLog.getGatewayRequestId(),
+            linkAddCareContext.getRequestId(),
             response.getBody().getErrorResponse().getMessage(),
             RequestStatus.ADD_CARE_CONTEXT_ERROR);
       }


### PR DESCRIPTION
- The logic in storing data in db is after making a post init request, because of the quick response the response is throwing a request not found error.
- To avoid that, before making a post request, store the data in db by request status as "INITIATING"
- Because of that the request and response are working seamlessly.