### PR TITLE
Removing unwanted query in finding patientReference during discovery

### DIFF
--- a/src/main/java/com/nha/abdm/wrapper/hip/HIUClient.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/HIUClient.java
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class HIUClient {
   private static final Logger log = LogManager.getLogger(HIUClient.class);
-  //The WebClient is throwing 404 not found where as RestTemplate is working //TODO
+  // The WebClient is throwing 404 not found where as RestTemplate is working //TODO
   // url: https://dev.abdm.gov.in/api-hiu/data/notification
   // url: https://dev.abdm.gov.in/patient-hiu/data/notification
   // These are the known url where WebClient is throwing 404 error.

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/link/userInitiated/LinkService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/link/userInitiated/LinkService.java
@@ -153,12 +153,14 @@ public class LinkService implements LinkInterface {
     String abhaAddress = requestLogService.getPatientId(linkRefNumber);
     String patientReference = requestLogService.getPatientReference(linkRefNumber);
     Patient patientWithAbha = patientRepo.findByAbhaAddress(abhaAddress);
-    Patient patientWithPatientRef = patientRepo.findByPatientReference(patientReference);
+    // Commenting patientReference because of redundant query since we have the same
+    // patientReference in requestLogs
+    //    Patient patientWithPatientRef = patientRepo.findByPatientReference(patientReference);
 
     if (patientWithAbha != null) {
       display = patientWithAbha.getPatientDisplay();
-    } else if (patientWithPatientRef != null) {
-      display = patientWithPatientRef.getPatientDisplay();
+    } else if (patientReference != null) {
+      display = patientReference;
     }
     log.info("onConfirm Abha address is: " + abhaAddress);
     if (abhaAddress == null) {


### PR DESCRIPTION
String abhaAddress = requestLogService.getPatientId(linkRefNumber);
String patientReference = requestLogService.getPatientReference(linkRefNumber);
Patient patientWithAbha = patientRepo.findByAbhaAddress(abhaAddress);
Patient patientWithPatientRef = patientRepo.findByPatientReference(patientReference);

- The above patientWithPatientRef is redundant during discovery and if patients with the same patientReference are throwing query error because of findOne.
- anyway we are picking up patient references from requestLogs which initially got from the patient repo.