### PR TITLE
Modified ConsentStatusResponse for consentDetails

### DIFF
--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/ConsentGatewayCallbackService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/ConsentGatewayCallbackService.java
@@ -135,14 +135,6 @@ public class ConsentGatewayCallbackService implements ConsentGatewayCallbackInte
                 consentArtefact.getId(),
                 notifyHIURequest.getNotification().getStatus());
           }
-          String gatewayRequestId =
-              consentRequestService.getGatewayRequestId(
-                  notifyHIURequest.getNotification().getConsentRequestId());
-          requestLogService.updateConsentResponse(
-              gatewayRequestId,
-              FieldIdentifiers.CONSENT_ON_NOTIFY_RESPONSE,
-              RequestStatus.CONSENT_ON_NOTIFY_RESPONSE_RECEIVED,
-              notifyHIURequest.getNotification());
         }
         OnNotifyRequest onNotifyRequest =
             OnNotifyRequest.builder()

--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/requests/callback/ConsentArtefact.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/requests/callback/ConsentArtefact.java
@@ -1,6 +1,7 @@
 /* (C) 2024 */
 package com.nha.abdm.wrapper.hiu.hrp.consent.requests.callback;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,4 +13,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ConsentArtefact {
   private String id;
+  private String hipId;
+  private List<String> careContextReference;
 }

--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/requests/callback/ConsentStatus.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/requests/callback/ConsentStatus.java
@@ -2,6 +2,7 @@
 package com.nha.abdm.wrapper.hiu.hrp.consent.requests.callback;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.nha.abdm.wrapper.hiu.hrp.consent.requests.DateRange;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,5 +22,7 @@ public class ConsentStatus {
   @JsonIgnore private String id;
 
   private String status;
+  private DateRange dateRange;
+  private String dataEraseAt;
   private List<ConsentArtefact> consentArtefacts;
 }


### PR DESCRIPTION
There is a need for consent details to be displayed on HIU UI by consent/status API for,
- The consent from consent/fetch API is stored In patientRepo are retrieved from the granted consentArtifacts from request-logs
- Checking the consent expiry timestamp and updating the status in consents of the patient repo as EXPIRED since those have to be handled by the wrapper.
- Displaying the consentStatus, dateRange, dataEraseAt, consentArtifacts on ConsentStatusResponse.