### PR TITLE
HIU Handling multiple dataPush for same transactionId 

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ Follow the steps to link care contexts. The linking can be achieved by two modes
         }
     },
     "consentDetails": { // GRANTED consent details
+        "grantedOn": "2024-04-19T15:33:46.146Z",
         "dateRange": {
             "from": "2023-02-16T12:45:18.548Z",
             "to": "2024-03-15T11:43:18.548Z"

--- a/src/main/java/com/nha/abdm/wrapper/common/models/Consent.java
+++ b/src/main/java/com/nha/abdm/wrapper/common/models/Consent.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Consent {
   private String status;
-  private String timestamp;
+  private String lastUpdatedOn;
+  private String grantedOn;
   private ConsentDetail consentDetail;
   private String signature;
 }

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/consent/ConsentService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/consent/ConsentService.java
@@ -68,7 +68,8 @@ public class ConsentService implements ConsentInterface {
           RespRequest.builder().requestId(hipNotifyRequest.getRequestId()).build();
       Consent consent =
           Consent.builder()
-              .timestamp(hipNotifyRequest.getTimestamp())
+              .grantedOn(hipNotifyRequest.getTimestamp())
+              .lastUpdatedOn(hipNotifyRequest.getTimestamp())
               .status(hipNotification.getStatus())
               .consentDetail(hipNotification.getConsentDetail())
               .signature(hipNotification.getSignature())

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/services/PatientService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/services/PatientService.java
@@ -258,7 +258,7 @@ public class PatientService {
     Bson update =
         Updates.combine(
             Updates.set("consents.$.status", consentStatus),
-            Updates.set("consents.$.timestamp", lastUpdated));
+            Updates.set("consents.$.lastUpdatedOn", lastUpdated));
     UpdateResult result = collection.updateOne(filter, update);
     log.debug("consent update result: ", result);
   }

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/services/RequestLogService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/services/RequestLogService.java
@@ -23,10 +23,7 @@ import com.nha.abdm.wrapper.hip.hrp.link.hipInitiated.responses.LinkOnAddCareCon
 import com.nha.abdm.wrapper.hip.hrp.link.hipInitiated.responses.LinkOnConfirmResponse;
 import com.nha.abdm.wrapper.hip.hrp.link.hipInitiated.responses.LinkOnInitResponse;
 import com.nha.abdm.wrapper.hip.hrp.link.userInitiated.responses.InitResponse;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -463,11 +460,19 @@ public class RequestLogService<T> {
                   .build())
           .build();
     }
-    Map<String, Object> map = requestLog.getRequestDetails();
+    Map<String, Object> map = requestLog.getResponseDetails();
     if (map == null) {
       map = new HashMap<>();
     }
-    map.put(FieldIdentifiers.ENCRYPTED_HEALTH_INFORMATION, healthInformationPushRequest);
+    List<HealthInformationPushRequest> healthInformationPushRequests = new ArrayList<>();
+    Object existingObject = map.get(FieldIdentifiers.ENCRYPTED_HEALTH_INFORMATION);
+    if (existingObject != null) {
+      List<HealthInformationPushRequest> existingList =
+          (List<HealthInformationPushRequest>) existingObject;
+      healthInformationPushRequests.addAll(existingList);
+    }
+    healthInformationPushRequests.add(healthInformationPushRequest);
+    map.put(FieldIdentifiers.ENCRYPTED_HEALTH_INFORMATION, healthInformationPushRequests);
     Update update = new Update();
     update.set(FieldIdentifiers.RESPONSE_DETAILS, map);
     update.set(FieldIdentifiers.STATUS, requestStatus);

--- a/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/tables/helpers/RequestStatus.java
+++ b/src/main/java/com/nha/abdm/wrapper/hip/hrp/database/mongo/tables/helpers/RequestStatus.java
@@ -46,7 +46,8 @@ public enum RequestStatus {
   HEALTH_INFORMATION_ON_REQUEST_ERROR("Error thrown by Gateway for onRequest done by HIP"),
   ENCRYPTED_HEALTH_INFORMATION_RECEIVED("Encrypted Health Information received by HIU from HIP"),
   ENCRYPTED_HEALTH_INFORMATION_ERROR(
-      "Error while receiving encrypted Health Information by HIU from HIP");
+      "Error while receiving encrypted Health Information by HIU from HIP"),
+  DECRYPTION_ERROR("Unable to decrypt the data sent by HIP");
 
   private String value;
 

--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/ConsentGatewayCallbackService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/ConsentGatewayCallbackService.java
@@ -215,7 +215,8 @@ public class ConsentGatewayCallbackService implements ConsentGatewayCallbackInte
       String patientId = onFetchRequest.getConsent().getConsentDetail().getPatient().getId();
       Consent consent =
           Consent.builder()
-              .timestamp(onFetchRequest.getTimestamp())
+              .lastUpdatedOn(onFetchRequest.getTimestamp())
+              .lastUpdatedOn(onFetchRequest.getTimestamp())
               .consentDetail(onFetchRequest.getConsent().getConsentDetail())
               .status(onFetchRequest.getConsent().getStatus())
               .build();

--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/HIUConsentService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/HIUConsentService.java
@@ -397,6 +397,7 @@ public class HIUConsentService implements HIUConsentInterface {
     Consent consentForDateRange = consentList.get(0);
     return FacadeConsentDetails.builder()
         .consent(consentStatusList)
+        .grantedOn(consentForDateRange.getGrantedOn())
         .hiTypes(consentForDateRange.getConsentDetail().getHiTypes())
         .dataEraseAt(consentForDateRange.getConsentDetail().getPermission().getDataEraseAt())
         .dateRange(consentForDateRange.getConsentDetail().getPermission().getDateRange())
@@ -406,7 +407,7 @@ public class HIUConsentService implements HIUConsentInterface {
   private ConsentArtefact createConsentArtefact(Consent consent) {
     return ConsentArtefact.builder()
         .id(consent.getConsentDetail().getConsentId())
-        .lastUpdated(consent.getTimestamp())
+        .lastUpdated(consent.getLastUpdatedOn())
         .hipId(consent.getConsentDetail().getHip().getId())
         .careContextReference(
             consent.getConsentDetail().getCareContexts().stream()

--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/responses/FacadeConsentDetails.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/consent/responses/FacadeConsentDetails.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class FacadeConsentDetails {
+  private String grantedOn;
   private DateRange dateRange;
   private String dataEraseAt;
   private List<String> hiTypes;

--- a/src/main/java/com/nha/abdm/wrapper/hiu/hrp/dataTransfer/HIUFacadeHealthInformationService.java
+++ b/src/main/java/com/nha/abdm/wrapper/hiu/hrp/dataTransfer/HIUFacadeHealthInformationService.java
@@ -191,16 +191,25 @@ public class HIUFacadeHealthInformationService implements HIUFacadeHealthInforma
           || Objects.isNull(responseDetails.get(FieldIdentifiers.ENCRYPTED_HEALTH_INFORMATION))) {
         return HealthInformationResponse.builder().status(requestLog.getStatus()).build();
       }
-      List<HealthInformationPushRequest> healthInformationPushRequest =
-          (List<HealthInformationPushRequest>)
-              responseDetails.get(FieldIdentifiers.ENCRYPTED_HEALTH_INFORMATION);
-      List<HealthInformationBundle> decryptedHealthInformationEntries =
-          getDecryptedHealthInformation(healthInformationPushRequest);
-      return HealthInformationResponse.builder()
-          .status(requestLog.getStatus())
-          .httpStatusCode(HttpStatus.OK)
-          .decryptedHealthInformationEntries(decryptedHealthInformationEntries)
-          .build();
+      try {
+        List<HealthInformationPushRequest> healthInformationPushRequest =
+            (List<HealthInformationPushRequest>)
+                responseDetails.get(FieldIdentifiers.ENCRYPTED_HEALTH_INFORMATION);
+        List<HealthInformationBundle> decryptedHealthInformationEntries =
+            getDecryptedHealthInformation(healthInformationPushRequest);
+        return HealthInformationResponse.builder()
+            .status(requestLog.getStatus())
+            .httpStatusCode(HttpStatus.OK)
+            .decryptedHealthInformationEntries(decryptedHealthInformationEntries)
+            .build();
+      } catch (Exception e) {
+        log.error(e.getMessage());
+        return HealthInformationResponse.builder()
+            .status(RequestStatus.DECRYPTION_ERROR)
+            .httpStatusCode(HttpStatus.UNPROCESSABLE_ENTITY)
+            .error("Unable to decrypt the data sent by HIP")
+            .build();
+      }
     } else {
       return HealthInformationResponse.builder()
           .status(requestLog.getStatus())
@@ -269,19 +278,27 @@ public class HIUFacadeHealthInformationService implements HIUFacadeHealthInforma
       String hiuNonce = consentCipherMapping.getNonce();
       List<HealthInformationEntry> healthInformationEntries =
           healthInformationPushRequest.getEntries();
-
       for (HealthInformationEntry healthInformationEntry : healthInformationEntries) {
-        decryptedHealthInformationEntries.add(
-            HealthInformationBundle.builder()
-                .bundleContent(
-                    decryptionManager.decryptedHealthInformation(
-                        hipNonce,
-                        hiuNonce,
-                        hiuPrivateKey,
-                        hipPublicKey,
-                        healthInformationEntry.getContent()))
-                .careContextReference(healthInformationEntry.getCareContextReference())
-                .build());
+        try {
+          decryptedHealthInformationEntries.add(
+              HealthInformationBundle.builder()
+                  .bundleContent(
+                      decryptionManager.decryptedHealthInformation(
+                          hipNonce,
+                          hiuNonce,
+                          hiuPrivateKey,
+                          hipPublicKey,
+                          healthInformationEntry.getContent()))
+                  .careContextReference(healthInformationEntry.getCareContextReference())
+                  .build());
+        } catch (Exception e) {
+          log.error(e.getMessage());
+          decryptedHealthInformationEntries.add(
+              HealthInformationBundle.builder()
+                  .bundleContent("ERROR: " + e.getMessage())
+                  .careContextReference(healthInformationEntry.getCareContextReference())
+                  .build());
+        }
       }
     }
     return decryptedHealthInformationEntries;


### PR DESCRIPTION
- Added garntedTimestamp in consent-status API
- If the HIP is sending multiple encrypted bundles to HIU wrapper in different /v1/transfer, storing them in the list and iterating while decrypting the data, these all are handled using transaction id.