### PR TITLE
Added retry mechanism for create session.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'info.debatty:java-string-similarity:2.0.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.14.0'
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.66'
+    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.5'
 }
 
 test {

--- a/src/main/java/com/nha/abdm/wrapper/common/RequestManager.java
+++ b/src/main/java/com/nha/abdm/wrapper/common/RequestManager.java
@@ -26,22 +26,14 @@ public class RequestManager {
       @Value("${useProxySettings}") final boolean useProxySettings,
       SessionManager sessionManager) {
     this.sessionManager = sessionManager;
-    if (useProxySettings) {
-      webClient =
-          WebClient.builder()
-              .baseUrl(gatewayBaseUrl)
-              .clientConnector(new ReactorClientHttpConnector(sessionManager.getHttpClient()))
-              .defaultHeaders(
-                  httpHeaders -> httpHeaders.addAll(sessionManager.setGatewayRequestHeaders()))
-              .build();
-    } else {
-      webClient =
-          WebClient.builder()
-              .baseUrl(gatewayBaseUrl)
-              .defaultHeaders(
-                  httpHeaders -> httpHeaders.addAll(sessionManager.setGatewayRequestHeaders()))
-              .build();
-    }
+    webClient =
+        WebClient.builder()
+            .baseUrl(gatewayBaseUrl)
+            .clientConnector(
+                new ReactorClientHttpConnector(sessionManager.getHttpClient(useProxySettings)))
+            .defaultHeaders(
+                httpHeaders -> httpHeaders.addAll(sessionManager.setGatewayRequestHeaders()))
+            .build();
   }
 
   // Initializing headers every time to avoid setting the old headers/session token and getting

--- a/src/main/java/com/nha/abdm/wrapper/common/requests/SessionManager.java
+++ b/src/main/java/com/nha/abdm/wrapper/common/requests/SessionManager.java
@@ -83,9 +83,9 @@ public class SessionManager {
 
   /**
    * The accessToken expires at 20 minutes post creating, using this scheduler refreshing the
-   * accessToken every 18 minutes to avoid Unauthorized error.
+   * accessToken every 15 minutes to avoid Unauthorized error.
    */
-  @Scheduled(initialDelay = 10 * 60 * 1000, fixedRate = 10 * 60 * 1000)
+  @Scheduled(initialDelay = 15 * 60 * 1000, fixedRate = 15 * 60 * 1000)
   @Retryable(
       value = {WebClientRequestException.class, ReadTimeoutException.class},
       maxAttempts = 5,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,3 +69,7 @@ server.port=8082
 useProxySettings=false
 proxyHost=
 proxyPort=8080
+
+spring.task.scheduling.pool.size=10
+connectionTimeout=3000
+responseTimeout=5


### PR DESCRIPTION
When Gateway does not respond to create session request, the thread is suspended for more than 15 minutes and even after that wrapper receives a WebClientRequestException.

Added a Retry mechanism to handle this scenario.
Also, added connection timeout and response timeout to webclient configuration.

These two intervals are configurable.